### PR TITLE
Update import paths due to repo name change

### DIFF
--- a/examples/activity_example.go
+++ b/examples/activity_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/heartrates_example.go
+++ b/examples/heartrates_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/personal_info_example.go
+++ b/examples/personal_info_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 )
 

--- a/examples/readiness_example.go
+++ b/examples/readiness_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/rest_mode_example.go
+++ b/examples/rest_mode_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/ring_configuration_example.go
+++ b/examples/ring_configuration_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/session_example.go
+++ b/examples/session_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/sleep_example.go
+++ b/examples/sleep_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/sleep_time_example.go
+++ b/examples/sleep_time_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/spo2_example.go
+++ b/examples/spo2_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/stress_example.go
+++ b/examples/stress_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/tag_example.go
+++ b/examples/tag_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/examples/workout_example.go
+++ b/examples/workout_example.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"os"
 	"time"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/austinmoody/go-oura
+module github.com/austinmoody/go_oura
 
 go 1.21

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/heartrates_test.go
+++ b/tests/heartrates_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/oura_test.go
+++ b/tests/oura_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"errors"
 	"fmt"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"io"
 	"net/http"
 	"net/url"

--- a/tests/personal_info_test.go
+++ b/tests/personal_info_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	go_oura "github.com/austinmoody/go-oura"
+	go_oura "github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/readiness_test.go
+++ b/tests/readiness_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/ring_configuration_test.go
+++ b/tests/ring_configuration_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	go_oura "github.com/austinmoody/go-oura"
+	go_oura "github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/sleep_test.go
+++ b/tests/sleep_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/sleep_time_test.go
+++ b/tests/sleep_time_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/spo2_test.go
+++ b/tests/spo2_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/stress_test.go
+++ b/tests/stress_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/tag_test.go
+++ b/tests/tag_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"

--- a/tests/workout_test.go
+++ b/tests/workout_test.go
@@ -2,7 +2,7 @@ package tests
 
 import (
 	"errors"
-	"github.com/austinmoody/go-oura"
+	"github.com/austinmoody/go_oura"
 	"net/http"
 	"net/http/httptest"
 	"reflect"


### PR DESCRIPTION
The repository name has been changed from 'go-oura' to 'go_oura'. This commit updates all import paths to reflect this name change across all example and test files in the project.