### PR TITLE
Refactor struct definitions in various Go files

### DIFF
--- a/daily_activity.go
+++ b/daily_activity.go
@@ -62,11 +62,7 @@ type Contributor struct {
 }
 
 // Met is a Metabolic Equivalent of Task Minutes.
-type Met struct {
-	Interval  float64   `json:"interval"`
-	Items     []float64 `json:"items"`
-	Timestamp time.Time `json:"timestamp"`
-}
+type Met IntervalItems
 
 type dailyActivityBase DailyActivity
 type dailyActivitiesBase DailyActivities

--- a/daily_readiness.go
+++ b/daily_readiness.go
@@ -22,16 +22,7 @@ type DailyReadinesses struct {
 
 // ReadinessContributors describes data points which contribute to the summary DailyReadiness score
 // JSON described at https://cloud.ouraring.com/v2/docs#operation/Single_daily_readiness_Document_v2_usercollection_daily_readiness__document_id__get
-type ReadinessContributors struct {
-	ActivityBalance     int `json:"activity_balance"`
-	BodyTemperature     int `json:"body_temperature"`
-	HrvBalance          int `json:"hrv_balance"`
-	PreviousDayActivity int `json:"previous_day_activity"`
-	PreviousNight       int `json:"previous_night"`
-	RecoveryIndex       int `json:"recovery_index"`
-	RestingHeartRate    int `json:"resting_heart_rate"`
-	SleepBalance        int `json:"sleep_balance"`
-}
+type ReadinessContributors Contributors
 
 // DailyReadiness describes your daily readiness
 type DailyReadiness struct {

--- a/session.go
+++ b/session.go
@@ -34,11 +34,7 @@ type Session struct {
 	MotionCountData          SessionDataItems `json:"motion_count"`
 }
 
-type SessionDataItems struct {
-	Interval  float64   `json:"interval"`
-	Items     []float64 `json:"items"`
-	Timestamp time.Time `json:"timestamp"`
-}
+type SessionDataItems IntervalItems
 
 type sessionBase Session
 type sessionsBase Sessions


### PR DESCRIPTION
The commit has refactored and simplified several struct definitions across multiple Go source files. Complex fields were removed and replaced with previously defined, more generic types, such as 'Contributors' and 'IntervalItems', to foster code reuse and improve maintainability.